### PR TITLE
イベント名をオープンセミナー2017@岡山に統一

### DIFF
--- a/about.html
+++ b/about.html
@@ -2,16 +2,16 @@
 <html lang="ja">
 <head>
 <meta charset="UTF-8">
-<meta name="description" content="オープンセミナー岡山2017公式ページ。オープンセミナーはソフトウェア技術をテーマにした無料セミナーです。">
+<meta name="description" content="オープンセミナー2017@岡山公式ページ。オープンセミナーはソフトウェア技術をテーマにした無料セミナーです。">
 <meta name="keywords" content="オープンセミナー,岡山,勉強会,IT,システム,SE,プログラマー,Web">
 <title>開催概要 | オープンセミナー2017@岡山</title>
 <meta name="viewport" content="width=device-width">
-<meta property="og:title" content="開催概要 | オープンセミナー岡山2017" />
+<meta property="og:title" content="開催概要 | オープンセミナー2017@岡山" />
 <meta property="og:type" content="article" />
 <meta property="og:url" content="http://okayama.open-seminar.org/" />
 <meta property="og:image" content="http://okayama.open-seminar.org/images/ogp_image.png" />
-<meta property="og:site_name" content="オープンセミナー岡山2017" />
-<meta property="og:description" content="オープンセミナー岡山2017公式ページ。オープンセミナーはソフトウェア技術をテーマにした無料セミナーです。" />
+<meta property="og:site_name" content="オープンセミナー2017@岡山" />
+<meta property="og:description" content="オープンセミナー2017@岡山公式ページ。オープンセミナーはソフトウェア技術をテーマにした無料セミナーです。" />
 <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css">
 <link rel="stylesheet" href="css/style.css">
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.2/jquery.min.js"></script>

--- a/index.html
+++ b/index.html
@@ -2,16 +2,16 @@
 <html lang="ja">
 <head>
 <meta charset="UTF-8">
-<meta name="description" content="オープンセミナー岡山2017公式ページ。オープンセミナーはソフトウェア技術をテーマにした無料セミナーです。">
+<meta name="description" content="オープンセミナー2017@岡山公式ページ。オープンセミナーはソフトウェア技術をテーマにした無料セミナーです。">
 <meta name="keywords" content="オープンセミナー,岡山,勉強会,IT,システム,SE,プログラマー,Web">
 <title>オープンセミナー2017@岡山</title>
 <meta name="viewport" content="width=device-width">
-<meta property="og:title" content="オープンセミナー岡山2017" />
+<meta property="og:title" content="オープンセミナー2017@岡山" />
 <meta property="og:type" content="website" />
 <meta property="og:url" content="http://okayama.open-seminar.org/" />
 <meta property="og:image" content="http://okayama.open-seminar.org/images/ogp_image.png" />
-<meta property="og:site_name" content="オープンセミナー岡山2017" />
-<meta property="og:description" content="オープンセミナー岡山2017公式ページ。オープンセミナーはソフトウェア技術をテーマにした無料セミナーです。" />
+<meta property="og:site_name" content="オープンセミナー2017@岡山" />
+<meta property="og:description" content="オープンセミナー2017@岡山公式ページ。オープンセミナーはソフトウェア技術をテーマにした無料セミナーです。" />
 <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css">
 <link rel="stylesheet" href="css/style.css">
 <script>

--- a/sponsor.html
+++ b/sponsor.html
@@ -2,16 +2,16 @@
 <html lang="ja">
 <head>
 <meta charset="UTF-8">
-<meta name="description" content="オープンセミナー岡山2017公式ページ。オープンセミナーはソフトウェア技術をテーマにした無料セミナーです。">
+<meta name="description" content="オープンセミナー2017@岡山公式ページ。オープンセミナーはソフトウェア技術をテーマにした無料セミナーです。">
 <meta name="keywords" content="オープンセミナー,岡山,勉強会,IT,システム,SE,プログラマー,Web">
 <title>協賛企業・協力・後援団体一覧 | オープンセミナー2017@岡山</title>
 <meta name="viewport" content="width=device-width">
-<meta property="og:title" content="協賛企業・協力・後援団体一覧 | オープンセミナー岡山2017" />
+<meta property="og:title" content="協賛企業・協力・後援団体一覧 | オープンセミナー2017@岡山" />
 <meta property="og:type" content="article" />
 <meta property="og:url" content="http://okayama.open-seminar.org/" />
 <meta property="og:image" content="http://okayama.open-seminar.org/images/ogp_image.png" />
-<meta property="og:site_name" content="オープンセミナー岡山2017" />
-<meta property="og:description" content="オープンセミナー岡山2017公式ページ。オープンセミナーはソフトウェア技術をテーマにした無料セミナーです。" />
+<meta property="og:site_name" content="オープンセミナー2017@岡山" />
+<meta property="og:description" content="オープンセミナー2017@岡山公式ページ。オープンセミナーはソフトウェア技術をテーマにした無料セミナーです。" />
 <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css">
 <link rel="stylesheet" href="css/style.css">
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.2/jquery.min.js"></script>


### PR DESCRIPTION
イベント名の表記がブレブレだったので修正 2017しか修正してません。