### PR TITLE
スポンサー画像の間隔を修正

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -68,10 +68,11 @@ body {}
 	#navi_list .navi_6 i { background:#ff1744; }
 	#navi_list .navi_7 i { background:#303f9f; }
 
-.footer_sponsor_area { background: #FFF; padding: 20px; border-top: solid 1px #424242; }
-.sponsor_rank_area { padding: 10px; margin-bottom: 15px; }
-.sponsor_rank_title { font-size: 20px; font-weight: bold; margin-bottom: 10px; }
-.sponsor_link_platina img { width: 300px; max-width: 100% }
+.footer_sponsor_area { background: #FFF; padding: 40px 20px 20px 20px; border-top: solid 1px #424242; }
+.sponsor_rank_area { padding: 10px; margin-bottom: 60px; }
+.sponsor_rank_title { font-size: 20px; font-weight: bold; margin-bottom: 20px; }
+.sponsor_link_platina { display: table-cell; height: 118px; text-align: center; vertical-align: middle; }
+.sponsor_link_platina img { width: 300px; max-width: 100%; }
 .sponsor_link_gold img { width: 229px; max-width: 100%}
 .sponsor_link_silver img { width: 200px; max-width: 100% }
 .sponsor_link_bronze img { width: 150px; max-width: 100% }


### PR DESCRIPTION
スマホでみたとき、見づらかったので修正しました。
HTMLは重複してるのをなおしたくなかったので、CSSでゴリおししました。

## 1カラムのとき before

![image](https://cloud.githubusercontent.com/assets/92595/23263791/a7b785c0-fa22-11e6-991e-8d8209730a29.png)

## 1カラムのとき after

![image](https://cloud.githubusercontent.com/assets/92595/23263894/ebeafb32-fa22-11e6-97fd-5aaa2aceecfe.png)

## 2カラムのとき before

![image](https://cloud.githubusercontent.com/assets/92595/23264091/8d763750-fa23-11e6-8beb-2ef7720f4e19.png)

## 2カラムのとき after

(プラチナスポンサーの見出しの下がすこしあきすぎてみえるので、個別にさげたいきはする

![image](https://cloud.githubusercontent.com/assets/92595/23264118/a2531ca6-fa23-11e6-8c44-9aaa0117a586.png)

## 3カラムのとき before

![image](https://cloud.githubusercontent.com/assets/92595/23264194/e10bde4c-fa23-11e6-80e5-5f6bf1786eaa.png)

## 3カラムのとき after

beforeのほうがいいかもしれない。

![image](https://cloud.githubusercontent.com/assets/92595/23264166/c97450b6-fa23-11e6-9afb-3f0aac9eb92a.png)



