### PR TITLE
nodeのバージョンを指定

### DIFF
--- a/.github/workflows/page.yaml
+++ b/.github/workflows/page.yaml
@@ -8,10 +8,21 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        node: [20]
+
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
+
+      - name: Setup node env
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
 
       - name: Install Dependencies
         run: npm install


### PR DESCRIPTION
プロジェクトのnodeのバージョンが20なのでCIのnodeバージョンも20に指定

追加したアクション https://github.com/actions/setup-node

エラーログ

```
Run npm install
npm ERR! code EBADENGINE
npm ERR! engine Unsupported engine
npm ERR! engine Not compatible with your version of node/npm: oso@1.0.0
npm ERR! notsup Not compatible with your version of node/npm: oso@1.0.0
npm ERR! notsup Required: {"node":"20.x"}
npm ERR! notsup Actual:   {"npm":"10.5.0","node":"v18.20.1"}

npm ERR! A complete log of this run can be found in: /home/runner/.npm/_logs/202[4](https://github.com/osokayama/osokayama.github.io/actions/runs/8608012509/job/23589564179#step:3:5)-04-08T23_37_57_624Z-debug-0.log
Error: Process completed with exit code 1.
```

https://github.com/osokayama/osokayama.github.io/actions/runs/8608012509/job/23589564179