### PR TITLE
fix: 詳細リンクを絶対パスにして直接アクセス時の404を修正

### DIFF
--- a/pages/speakers.vue
+++ b/pages/speakers.vue
@@ -73,7 +73,7 @@ export default {
   methods: {
     show (speaker) {
       if (!this.timetable.timetable[speaker]) return
-      navigateTo(`detail/?speaker=${speaker}`)
+      navigateTo(`/detail/?speaker=${speaker}`)
     }
   }
 }

--- a/pages/timetable.vue
+++ b/pages/timetable.vue
@@ -202,7 +202,7 @@ export default {
   methods: {
     show (speaker) {
       if (!this.timetable.timetable[speaker]) return
-      navigateTo(`detail/?speaker=${speaker}`)
+      navigateTo(`/detail/?speaker=${speaker}`)
     }
   }
 }

--- a/tests/unit/speakers.test.ts
+++ b/tests/unit/speakers.test.ts
@@ -35,7 +35,7 @@ describe('pages/speakers.vue', () => {
     const wrapper = await mountSuspended(SpeakersPage)
     const cell = wrapper.find('td[class*="hover"]')
     await cell.trigger('click')
-    expect(navigateToMock).toHaveBeenCalledWith('detail/?speaker=aknow')
+    expect(navigateToMock).toHaveBeenCalledWith('/detail/?speaker=aknow')
   })
 
   it('kyoro 行クリックで navigateTo が呼ばれる', async () => {
@@ -43,34 +43,34 @@ describe('pages/speakers.vue', () => {
     const cells = wrapper.findAll('td.siimple-table-cell.hover')
     const kyoroCell = cells[1]
     await kyoroCell.trigger('click')
-    expect(navigateToMock).toHaveBeenCalledWith('detail/?speaker=kyoro')
+    expect(navigateToMock).toHaveBeenCalledWith('/detail/?speaker=kyoro')
   })
 
   it('kiryu 行クリックで navigateTo が呼ばれる', async () => {
     const wrapper = await mountSuspended(SpeakersPage)
     const cells = wrapper.findAll('td.siimple-table-cell.hover')
     await cells[2].trigger('click')
-    expect(navigateToMock).toHaveBeenCalledWith('detail/?speaker=kiryu')
+    expect(navigateToMock).toHaveBeenCalledWith('/detail/?speaker=kiryu')
   })
 
   it('koba789 行クリックで navigateTo が呼ばれる', async () => {
     const wrapper = await mountSuspended(SpeakersPage)
     const cells = wrapper.findAll('td.siimple-table-cell.hover')
     await cells[3].trigger('click')
-    expect(navigateToMock).toHaveBeenCalledWith('detail/?speaker=koba789')
+    expect(navigateToMock).toHaveBeenCalledWith('/detail/?speaker=koba789')
   })
 
   it('hsjoihs 行クリックで navigateTo が呼ばれる', async () => {
     const wrapper = await mountSuspended(SpeakersPage)
     const cells = wrapper.findAll('td.siimple-table-cell.hover')
     await cells[4].trigger('click')
-    expect(navigateToMock).toHaveBeenCalledWith('detail/?speaker=hsjoihs')
+    expect(navigateToMock).toHaveBeenCalledWith('/detail/?speaker=hsjoihs')
   })
 
   it('majima 行クリックで navigateTo が呼ばれる', async () => {
     const wrapper = await mountSuspended(SpeakersPage)
     const cells = wrapper.findAll('td.siimple-table-cell.hover')
     await cells[5].trigger('click')
-    expect(navigateToMock).toHaveBeenCalledWith('detail/?speaker=majima')
+    expect(navigateToMock).toHaveBeenCalledWith('/detail/?speaker=majima')
   })
 })

--- a/tests/unit/timetable.test.ts
+++ b/tests/unit/timetable.test.ts
@@ -39,41 +39,41 @@ describe('pages/timetable.vue', () => {
     const wrapper = await mountSuspended(TimetablePage)
     const cells = wrapper.findAll('td.siimple-table-cell.hover')
     await cells[0].trigger('click')
-    expect(navigateToMock).toHaveBeenCalledWith('detail/?speaker=aknow')
+    expect(navigateToMock).toHaveBeenCalledWith('/detail/?speaker=aknow')
   })
 
   it('hsjoihs セッションクリックで navigateTo が呼ばれる', async () => {
     const wrapper = await mountSuspended(TimetablePage)
     const cells = wrapper.findAll('td.siimple-table-cell.hover')
     await cells[1].trigger('click')
-    expect(navigateToMock).toHaveBeenCalledWith('detail/?speaker=hsjoihs')
+    expect(navigateToMock).toHaveBeenCalledWith('/detail/?speaker=hsjoihs')
   })
 
   it('koba789 セッションクリックで navigateTo が呼ばれる', async () => {
     const wrapper = await mountSuspended(TimetablePage)
     const cells = wrapper.findAll('td.siimple-table-cell.hover')
     await cells[2].trigger('click')
-    expect(navigateToMock).toHaveBeenCalledWith('detail/?speaker=koba789')
+    expect(navigateToMock).toHaveBeenCalledWith('/detail/?speaker=koba789')
   })
 
   it('majima セッションクリックで navigateTo が呼ばれる', async () => {
     const wrapper = await mountSuspended(TimetablePage)
     const cells = wrapper.findAll('td.siimple-table-cell.hover')
     await cells[3].trigger('click')
-    expect(navigateToMock).toHaveBeenCalledWith('detail/?speaker=majima')
+    expect(navigateToMock).toHaveBeenCalledWith('/detail/?speaker=majima')
   })
 
   it('kiryu セッションクリックで navigateTo が呼ばれる', async () => {
     const wrapper = await mountSuspended(TimetablePage)
     const cells = wrapper.findAll('td.siimple-table-cell.hover')
     await cells[4].trigger('click')
-    expect(navigateToMock).toHaveBeenCalledWith('detail/?speaker=kiryu')
+    expect(navigateToMock).toHaveBeenCalledWith('/detail/?speaker=kiryu')
   })
 
   it('kyoro セッションクリックで navigateTo が呼ばれる', async () => {
     const wrapper = await mountSuspended(TimetablePage)
     const cells = wrapper.findAll('td.siimple-table-cell.hover')
     await cells[5].trigger('click')
-    expect(navigateToMock).toHaveBeenCalledWith('detail/?speaker=kyoro')
+    expect(navigateToMock).toHaveBeenCalledWith('/detail/?speaker=kyoro')
   })
 })


### PR DESCRIPTION
## 概要

タイムテーブル・スピーカー一覧の各セッションをクリックして詳細ページへ遷移する際、特定のアクセス経路で404になる不具合を修正しました。

## 原因

`pages/timetable.vue` と `pages/speakers.vue` の `show` メソッドで、`navigateTo` の遷移先が相対パス（`detail/?speaker=...`）になっていました。

そのため、末尾スラッシュ付きのURL（`/timetable/`）から直接アクセスしてセッションをクリックすると、相対解決によって `/timetable/detail/?speaker=...` という存在しないルートへ遷移し、404になっていました。

一方、サイト内のリンク経由（末尾スラッシュ無しのルート扱い）で遷移した場合は `/detail/?speaker=...` に解決されるため正常に動作しており、「経路によって挙動が変わる」不思議な現象になっていました。

## 修正内容

`navigateTo` の遷移先を絶対パス（`/detail/?speaker=...`）に変更し、アクセス経路に依存せず常に正しい詳細ページへ遷移するようにしました。

- `pages/timetable.vue`
- `pages/speakers.vue`

## 動作確認

ローカルで `npm run dev` を起動し、以下を確認しました。

- `/detail/?speaker=aknow` → 200 OK
- タイムテーブル画面（`/timetable/`）からセッションをクリック → `/detail/?speaker=aknow` へ正しく遷移し、講師詳細ページが表示されることをブラウザで確認

なお `/timetable/detail/?speaker=aknow` は元々存在しないルートのため、直接アクセスすれば404になります（本修正の対象外）。