### PR TITLE
スタッフ名の高さを65pxから90pxに変更

### DIFF
--- a/pages/staff.vue
+++ b/pages/staff.vue
@@ -99,7 +99,7 @@ export default {
   width: 100%;
   padding-bottom: 10px;
 }
-.oso-staff-names { height: 65px; }
+.oso-staff-names { height: 90px; }
 .oso-staff-name { font-size: 20px; }
 .oso-staff-name,.oso-staff-roll,.oso-staff-sns { padding-left: 10px; padding-right: 10px; padding-bottom: 5px; }
 .oso-staff-roll { height: 26px; }


### PR DESCRIPTION
![image.png](https://github.com/user-attachments/assets/c9cbdfd5-7940-48d0-a29f-68a301a8cf39)
上記のようにアイコンが実行委員長にかぶっていたので調整